### PR TITLE
Detect ajax requests using wider criteria.

### DIFF
--- a/HARParser.js
+++ b/HARParser.js
@@ -9,7 +9,12 @@ define( ["handlebars", "lodash"],
             // only care about the XHR requests
             .filter(function (e) {
               return _.find(e.response.headers, function (h) {
-                return h.name === "X-Requested-With" && h.value === "XMLHttpRequest";
+                var requestedWith =
+                  h.name === "X-Requested-With" && h.value === "XMLHttpRequest";
+                var accessControl =
+                  h.name = "Access-Control-Allow-Origin"
+
+                return requestedWith || accessControl;
               });
             })
             .map(function (e) {


### PR DESCRIPTION
- They may also have the `Access-Control-Allow-Origin` header.
- "having other checks in place will be important."
  https://davidwalsh.name/detect-ajax

This was causing mock generation to fail.
